### PR TITLE
Update sse.py to preserve url base

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -61,7 +61,8 @@ async def sse_client(
                                 logger.debug(f"Received SSE event: {sse.event}")
                                 match sse.event:
                                     case "endpoint":
-                                        endpoint_url = urljoin(url, sse.data)
+                                        uri_base = url.rsplit("/sse", 1)[0]
+                                        endpoint_url = urljoin(uri_base + "/", sse.data.lstrip("/"))
                                         logger.info(
                                             f"Received endpoint URL: {endpoint_url}"
                                         )


### PR DESCRIPTION
fix: preserve base path when joining /messages from SSE endpoint

Previous behavour, a MCP server at:
https://my-mcp-server.com/mcp/weather-alerts/sse

would fail to connect to messages as the endpoint would be called as:

https://my-mcp-server.com/messages

It should be:

https://my-mcp-server.com/mcp/weather-alerts/messages